### PR TITLE
Prefix for group name

### DIFF
--- a/internal/awslogs/stream.go
+++ b/internal/awslogs/stream.go
@@ -32,6 +32,7 @@ const (
 type StreamParams struct {
 	Region      string
 	Directory   string
+	Prefix      string
 	SkipPattern string
 	File        os.FileInfo
 	New         bool
@@ -53,7 +54,7 @@ func Stream(params StreamParams) error {
 		Config: map[string]string{
 			ConfigRegion:      params.Region,
 			ConfigCreateGroup: "true",
-			ConfigGroup:       namespace,
+			ConfigGroup:       getGroupName(params.Prefix, namespace),
 			ConfigStream:      fmt.Sprintf("%s-%s", pod, container),
 		},
 	})
@@ -138,4 +139,13 @@ func Stream(params StreamParams) error {
 	filelogger.Infoln("Finished streaming")
 
 	return nil
+}
+
+// Helper function to apply a prefix to a group name if it exists.
+func getGroupName(prefix, name string) string {
+	if prefix != "" {
+		return fmt.Sprintf("%s-%s", prefix, name)
+	}
+
+	return name
 }

--- a/internal/awslogs/stream_test.go
+++ b/internal/awslogs/stream_test.go
@@ -1,0 +1,12 @@
+package awslogs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetGroupName(t *testing.T) {
+	assert.Equal(t, "prefix-name", getGroupName("prefix", "name"))
+	assert.Equal(t, "name", getGroupName("", "name"))
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 )
 
 var (
+	cliPrefix     = kingpin.Flag("prefix", "Prefix to apply to CloudWatch Logs group names.").Envar("K8S_CLOUDWATCHLOGS_PREFIX").String()
 	cliPrometheus = kingpin.Flag("prometheus", "Endpoint which Prometheus metrics can be scraped.").Envar("K8S_CLOUDWATCHLOGS_PROMETHEUS_PORT").Default(":9000").String()
 	cliRegion     = kingpin.Flag("region", "Region which logs will be stored.").Envar("AWS_REGION").Default("ap-southeast-2").String()
 	cliIgnore     = kingpin.Flag("ingore", "Ignore lines by using regex.").Envar("K8S_CLOUDWATCHLOGS_IGNORE").Default("liveness|healthz").String()
@@ -84,6 +85,7 @@ func watcher(stop <-chan struct{}) error {
 			params := awslogs.StreamParams{
 				Region:      *cliRegion,
 				Directory:   *cliDirectory,
+				Prefix:      *cliPrefix,
 				SkipPattern: *cliIgnore,
 				File:        file,
 				New:         false,
@@ -115,6 +117,7 @@ func watcher(stop <-chan struct{}) error {
 			params := awslogs.StreamParams{
 				Region:      *cliRegion,
 				Directory:   *cliDirectory,
+				Prefix:      *cliPrefix,
 				SkipPattern: *cliIgnore,
 				File:        file,
 				New:         true,


### PR DESCRIPTION
Adds a prefix for when running multiple clusters on the same account.